### PR TITLE
Pass tag param to createElement, not string literal

### DIFF
--- a/jzed.js
+++ b/jzed.js
@@ -91,7 +91,7 @@ function $toggle(node, className) {
 }
 
 function $new(tag, id, html) {
-    var new_tag = document.createElement("div");
+    var new_tag = document.createElement(tag);
     new_tag.id = id;
     new_tag.innerHTML = html;
     return new_tag;


### PR DESCRIPTION
This is the bug I was telling you about.

$new always returns a div element when I think the intention is to return whatever element is represented by the tag parameter.
