### PR TITLE
Fixed $next() and $previous() not returning anything

### DIFF
--- a/jzed.js
+++ b/jzed.js
@@ -63,11 +63,11 @@ function $each(arr, cb) {
 }
 
 function $next(node) {
-    node.nextElementSibling;
+    return node.nextElementSibling;
 }
 
 function $previous(node) {
-    node.previousElementSibling;
+    return node.previousElementSibling;
 }
 
 function $siblings(node) {


### PR DESCRIPTION
Unless they're used for a side-effect I'm not aware of, I guess that $next() and $previous() should return the next/previous node right?
