### PR TITLE
Fix undefined variable in $siblings()

### DIFF
--- a/jzed.js
+++ b/jzed.js
@@ -71,7 +71,7 @@ function $previous(node) {
 }
 
 function $siblings(node) {
-    return $filter(node.parentNode.children, function (child) { return child !== el; });
+    return $filter(node.parentNode.children, function (child) { return child !== node; });
 }
 
 function $style() {


### PR DESCRIPTION
The filtering predicate in `$siblings()` compares to an undefined variable `el`, which should be presumably `node`.
