### PR TITLE
Fixing reference to passed in attribute

### DIFF
--- a/jzed.js
+++ b/jzed.js
@@ -160,7 +160,7 @@ function $outer_html(node) {
 }
 
 function $replace_with(node, newhtml) {
-    node.outerHTML = string;
+    node.outerHTML = newhtml;
 }
 
 function $matches(node, selector) {


### PR DESCRIPTION
$replace_with was referencing `string` instead of the passed in attribute of `newhtml`.
